### PR TITLE
Updated link to Edge Add-ons store in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Since PocketTube is not fully open-source, this repository serves as a place for
 - [Chrome](//chrome.google.com/webstore/detail/pockettube-youtube-subscr/kdmnjgijlmjgmimahnillepgcgeemffb)
 - [Firefox](//addons.mozilla.org/en-US/firefox/addon/youtube-subscription-groups)
 - [Safari](//pockettube.io/install/PocketTube.dmg)
-- [Edge](//microsoftedge.microsoft.com/addons/Microsoft-Edge-Extensions-Home)
+- [Edge](//microsoftedge.microsoft.com/addons/detail/pockettube-youtube-subsc/klfeohnijmogpjoeenglhonjfiacajpp)
 - [Opera](//addons.opera.com/en/extensions/details/pockettube-youtube-subscription-manager)
 
 ### Mobile Apps:


### PR DESCRIPTION
hi!

I've just updated the link for Edge to go to the plugin directly.
I took the link 1:1 from https://pockettube.io/